### PR TITLE
refactor: use domain titles in page headings instead of IDs

### DIFF
--- a/src/main/frontend/generated/jar-resources/index.d.ts
+++ b/src/main/frontend/generated/jar-resources/index.d.ts
@@ -1,2 +1,1 @@
-export * from './copilot'
-export {}
+export * from './Flow';

--- a/src/main/frontend/generated/vaadin.ts
+++ b/src/main/frontend/generated/vaadin.ts
@@ -1,5 +1,53 @@
 import './vaadin-featureflags.js';
 
+import 'Frontend/generated/jar-resources/copilot.js';
+// @ts-ignore
+if (import.meta.hot) {
+  // @ts-ignore
+  import.meta.hot.on('vite:beforeUpdate', (e:any) => {
+    if ((window as any).Vaadin.copilot?.disableViteHmr) {
+        e.updates = [];
+    }
+  });
+  // @ts-ignore
+  import.meta.hot.on('vite:beforeFullReload', (payload:any) => {
+    if ((window as any).Vaadin.copilot?.disableViteHmr) {
+        payload.path = "something-not-used-in-the-app-to-prevent-reload.html";
+    }
+  });
+  // @ts-ignore
+  import.meta.hot.on('vite:afterUpdate', () => {
+    const eventbus = (window as any).Vaadin.copilot.eventbus;
+    if (eventbus) {
+      eventbus.emit('vite-after-update',{});
+    }
+  });
+}
+
+import '@vaadin/vertical-layout/vaadin-vertical-layout.js';
+import '@vaadin/horizontal-layout/vaadin-horizontal-layout.js';
+import '@vaadin/context-menu/vaadin-context-menu.js';
+import '@vaadin/checkbox/vaadin-checkbox.js';
+import '@vaadin/text-field/vaadin-text-field.js';
+import '@vaadin/text-area/vaadin-text-area.js';
+import '@vaadin/menu-bar/vaadin-menu-bar.js';
+import '@vaadin/grid/vaadin-grid.js';
+import '@vaadin/grid/vaadin-grid-tree-column.js';
+import '@vaadin/details/vaadin-details.js';
+import '@vaadin/select/vaadin-select.js';
+import '@vaadin/overlay/vaadin-overlay.js';
+import '@vaadin/popover/vaadin-popover.js';
+import '@vaadin/list-box/vaadin-list-box.js';
+import '@vaadin/combo-box/vaadin-combo-box.js';
+import '@vaadin/item/vaadin-item.js';
+import '@vaadin/tabsheet/vaadin-tabsheet.js';
+import '@vaadin/dialog/vaadin-dialog.js';
+import '@vaadin/confirm-dialog/vaadin-confirm-dialog.js';
+import '@vaadin/multi-select-combo-box/vaadin-multi-select-combo-box.js';
+import '@vaadin/radio-group/vaadin-radio-group.js';
+import '@vaadin/tooltip/vaadin-tooltip.js';
+import '@vaadin/icons/vaadin-iconset.js';
+import '@vaadin/icon/vaadin-icon.js';
 import './index';
 
 import './vaadin-react.js';
@@ -9,3 +57,9 @@ import './app-shell-imports.js';
 import './css.generated.js';
 import { applyCss } from './css.generated.js';
 applyCss(document);
+
+import { Outlet } from 'react-router';
+(window as any).Vaadin ??= {};
+(window as any).Vaadin.copilot ??= {};
+(window as any).Vaadin.copilot._ref ??= {};
+(window as any).Vaadin.copilot._ref.Outlet = Outlet;

--- a/src/main/java/com/pdg/adventure/view/adventure/AdventureEditorView.java
+++ b/src/main/java/com/pdg/adventure/view/adventure/AdventureEditorView.java
@@ -205,7 +205,7 @@ public class AdventureEditorView extends VerticalLayout
             return;
         }
         isNewAdventure = false;
-        pageTitle = "Edit Adventure #" + anAdventureId;
+        pageTitle = "Edit Adventure: " + adventureData.getTitle();
     }
 
     private void setUpNewEdit() {

--- a/src/main/java/com/pdg/adventure/view/command/CommandEditorView.java
+++ b/src/main/java/com/pdg/adventure/view/command/CommandEditorView.java
@@ -38,6 +38,7 @@ import com.pdg.adventure.view.location.LocationsMainLayout;
 import com.pdg.adventure.view.location.LocationsMenuView;
 import com.pdg.adventure.view.support.AdventureRouteResolver;
 import com.pdg.adventure.view.support.RouteIds;
+import com.pdg.adventure.view.support.ViewSupporter;
 
 @Route(value = "author/adventures/:adventureId/locations/:locationId/commands/:commandId/edit", layout = LocationsMainLayout.class)
 @RouteAlias(value = "author/adventures/:adventureId/locations/:locationId/commands/new", layout = LocationsMainLayout.class)
@@ -370,7 +371,7 @@ public class CommandEditorView extends VerticalLayout
             // characters from vocabulary text. AdventureRouteResolver.decodeRouteParam performs
             // percent-only decoding with graceful fallback for both cases.
             commandId = AdventureRouteResolver.decodeRouteParam(optionalCommandId.get());
-            pageTitle = "Edit Command #" + commandId;
+            pageTitle = "Edit Command: " + ViewSupporter.formatDescription(new CommandDescriptionData(commandId));
         } else {
             pageTitle = "New Command";
         }

--- a/src/main/java/com/pdg/adventure/view/command/CommandsMenuView.java
+++ b/src/main/java/com/pdg/adventure/view/command/CommandsMenuView.java
@@ -176,7 +176,6 @@ public class CommandsMenuView extends VerticalLayout
         }
         final Optional<String> optionalItemId = event.getRouteParameters().get(RouteIds.ITEM_ID.getValue());
         if (optionalItemId.isPresent()) {
-            pageTitle = "Commands for item #" + optionalItemId.get();
             Optional<ItemData> resolvedItem = AdventureRouteResolver.resolveItem(resolvedLocation.get(), event);
             if (resolvedItem.isEmpty()) {
                 event.forwardTo(ItemsMenuView.class, new RouteParameters(
@@ -184,10 +183,10 @@ public class CommandsMenuView extends VerticalLayout
                         new RouteParam(RouteIds.LOCATION_ID.getValue(), resolvedLocation.get().getId())));
                 return;
             }
+            pageTitle = "Commands for " + ViewSupporter.formatDescription(resolvedItem.get());
             setData(resolvedAdventure.get(), resolvedLocation.get(), resolvedItem.get());
         } else {
-            String locationId = event.getRouteParameters().get(LOCATION_ID.getValue()).orElse("666");
-            pageTitle = "Commands for location #" + locationId;
+            pageTitle = "Commands for " + ViewSupporter.formatDescription(resolvedLocation.get());
             setData(resolvedAdventure.get(), resolvedLocation.get());
         }
     }

--- a/src/main/java/com/pdg/adventure/view/component/AdventureGrid.java
+++ b/src/main/java/com/pdg/adventure/view/component/AdventureGrid.java
@@ -27,7 +27,7 @@ public class AdventureGrid<T> extends Grid<T> {
         addItemDoubleClickListener(_ ->
                                            NavigationHelper.navigateTo(targetView, new RouteParameters(
                                                    new RouteParam(RouteIds.ADVENTURE_ID.getValue(), anAdventureId),
-                                                   new RouteParam("locationId", aLocationId))));
+                                                   new RouteParam(RouteIds.LOCATION_ID.getValue(), aLocationId))));
         return this;
     }
 

--- a/src/main/java/com/pdg/adventure/view/direction/DirectionEditorView.java
+++ b/src/main/java/com/pdg/adventure/view/direction/DirectionEditorView.java
@@ -276,13 +276,11 @@ public class DirectionEditorView extends VerticalLayout
             return;
         }
         final Optional<String> optionalDirectionId = event.getRouteParameters().get(RouteIds.DIRECTION_ID.getValue());
-        if (optionalDirectionId.isPresent()) {
-            directionId = optionalDirectionId.get();
-            pageTitle = "Edit Direction #" + directionId;
-        } else {
-            pageTitle = "New Direction";
-        }
+        optionalDirectionId.ifPresent(id -> directionId = id);
         setData(resolvedLocation.get(), resolvedAdventure.get());
+        pageTitle = optionalDirectionId.isPresent()
+                ? "Edit Direction: " + ViewSupporter.formatDescription(directionData.getDescriptionData())
+                : "New Direction";
     }
 
     @Override

--- a/src/main/java/com/pdg/adventure/view/direction/DirectionsMenuView.java
+++ b/src/main/java/com/pdg/adventure/view/direction/DirectionsMenuView.java
@@ -137,7 +137,7 @@ public class DirectionsMenuView extends VerticalLayout implements HasDynamicTitl
         }
         Optional<String> locId = event.getRouteParameters().get(RouteIds.LOCATION_ID.getValue());
         if (locId.isPresent()) {
-            pageTitle = "Exits for location #" + locId.get();
+            pageTitle = "Exits for " + ViewSupporter.formatDescription(resolvedLocation.get());
         } else {
             pageTitle = "Exits";
         }

--- a/src/main/java/com/pdg/adventure/view/item/ItemEditorView.java
+++ b/src/main/java/com/pdg/adventure/view/item/ItemEditorView.java
@@ -416,13 +416,11 @@ public class ItemEditorView extends VerticalLayout
             return;
         }
         final Optional<String> optionalItemId = event.getRouteParameters().get(RouteIds.ITEM_ID.getValue());
-        if (optionalItemId.isPresent()) {
-            itemId = optionalItemId.get();
-            pageTitle = "Edit Item #" + itemId;
-        } else {
-            pageTitle = "New Item";
-        }
+        optionalItemId.ifPresent(id -> itemId = id);
         setData(resolvedAdventure.get(), resolvedLocation.get());
+        pageTitle = optionalItemId.isPresent()
+                ? "Edit Item: " + ViewSupporter.formatDescription(itemData)
+                : "New Item";
     }
 
     @Override

--- a/src/main/java/com/pdg/adventure/view/location/LocationEditorView.java
+++ b/src/main/java/com/pdg/adventure/view/location/LocationEditorView.java
@@ -35,6 +35,7 @@ import com.pdg.adventure.view.direction.DirectionsMenuView;
 import com.pdg.adventure.view.item.ItemsMenuView;
 import com.pdg.adventure.view.support.AdventureRouteResolver;
 import com.pdg.adventure.view.support.RouteIds;
+import com.pdg.adventure.view.support.ViewSupporter;
 
 @Route(value = "author/adventures/:adventureId/locations/:locationId/edit", layout = LocationsMainLayout.class)
 @RouteAlias(value = "author/adventures/:adventureId/locations/new", layout = LocationsMainLayout.class)
@@ -234,13 +235,11 @@ public class LocationEditorView extends VerticalLayout
             return;
         }
         final Optional<String> optionalLocationId = event.getRouteParameters().get(RouteIds.LOCATION_ID.getValue());
-        if (optionalLocationId.isPresent()) {
-            locationId = optionalLocationId.get();
-            pageTitle = "Edit Location #" + locationId;
-        } else {
-            pageTitle = "New Location";
-        }
+        optionalLocationId.ifPresent(id -> locationId = id);
         setData(resolvedAdventure.get());
+        pageTitle = optionalLocationId.isPresent()
+                ? "Edit Location: " + ViewSupporter.formatDescription(locationData)
+                : "New Location";
     }
 
     @Override

--- a/src/main/java/com/pdg/adventure/view/message/MessagesMenuView.java
+++ b/src/main/java/com/pdg/adventure/view/message/MessagesMenuView.java
@@ -269,7 +269,7 @@ public class MessagesMenuView extends VerticalLayout implements HasDynamicTitle,
         }
         Optional<String> adventureId = event.getRouteParameters().get(RouteIds.ADVENTURE_ID.getValue());
         if (adventureId.isPresent()) {
-            pageTitle = "Messages for Adventure #" + adventureId.get();
+            pageTitle = "Messages for " + resolvedAdventure.get().getTitle();
         } else {
             pageTitle = "Messages";
         }

--- a/src/test/java/com/pdg/adventure/view/adventure/AdventureEditorViewRoutingTest.java
+++ b/src/test/java/com/pdg/adventure/view/adventure/AdventureEditorViewRoutingTest.java
@@ -1,9 +1,7 @@
-package com.pdg.adventure.view.message;
+package com.pdg.adventure.view.adventure;
 
 import com.vaadin.browserless.BrowserlessTest;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.RouteParam;
 import com.vaadin.flow.router.RouteParameters;
@@ -13,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,36 +19,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pdg.adventure.model.AdventureData;
-import com.pdg.adventure.model.MessageData;
 import com.pdg.adventure.security.model.UserData;
 import com.pdg.adventure.server.security.service.AdventureAccessService;
-import com.pdg.adventure.server.storage.service.AdventureService;
-import com.pdg.adventure.server.storage.service.MessageService;
-import com.pdg.adventure.view.adventure.AdventuresMenuView;
 import com.pdg.adventure.view.support.RouteIds;
 
-class MessagesMenuViewRoutingTest extends BrowserlessTest {
+class AdventureEditorViewRoutingTest extends BrowserlessTest {
 
-    private MessageService messageService;
-    private AdventureService adventureService;
     private AdventureAccessService accessService;
-    private MessagesMenuView view;
+    private AdventureEditorView view;
 
     @BeforeEach
     void setUp() {
-        messageService = mock(MessageService.class);
-        adventureService = mock(AdventureService.class);
         accessService = mock(AdventureAccessService.class);
         UserData testUser = new UserData();
         testUser.setUsername("test-author");
         testUser.setRoles(Set.of());
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities()));
-        view = new MessagesMenuView(messageService, adventureService, accessService);
+        view = new AdventureEditorView(accessService);
         UI.getCurrent().add(view);
     }
 
@@ -67,32 +56,26 @@ class MessagesMenuViewRoutingTest extends BrowserlessTest {
     }
 
     @Test
-    void beforeEnter_validAdventureId_populatesMessagesGrid() {
-        MessageData message = new MessageData();
+    void beforeEnter_validAdventureId_setsTitleFromAdventureTitle() {
         AdventureData adventure = new AdventureData();
         adventure.setId("adv-1");
         adventure.setTitle("The Demo");
-        adventure.setMessages(Map.of("msg-1", message));
+        adventure.setLocationData(new HashMap<>());
         when(accessService.findAdventureById(eq("adv-1"), any(UserData.class)))
                 .thenReturn(Optional.of(adventure));
 
         view.beforeEnter(eventWithAdventureId("adv-1"));
 
-        assertThat(view.getPageTitle()).isEqualTo("Messages for The Demo");
-        Grid<?> grid = find(Grid.class, view).single();
-        assertThat(test(grid).size()).isEqualTo(1);
+        assertThat(view.getPageTitle()).isEqualTo("Edit Adventure: The Demo");
     }
 
     @Test
-    void beforeEnter_unknownAdventureId_forwardsToAdventuresMenuView() {
-        when(accessService.findAdventureById(eq("missing"), any(UserData.class)))
-                .thenReturn(Optional.empty());
-        BeforeEnterEvent event = eventWithAdventureId("missing");
+    void beforeEnter_noAdventureId_setsNewAdventureTitle() {
+        BeforeEnterEvent event = mock(BeforeEnterEvent.class);
+        when(event.getRouteParameters()).thenReturn(new RouteParameters());
 
         view.beforeEnter(event);
 
-        verify(event).forwardTo(AdventuresMenuView.class);
-        Notification notification = find(Notification.class).single();
-        assertThat(test(notification).getText()).isEqualTo("Adventure not found or access denied: missing");
+        assertThat(view.getPageTitle()).isEqualTo("A new adventure awaits!");
     }
 }

--- a/src/test/java/com/pdg/adventure/view/command/CommandEditorViewRoutingTest.java
+++ b/src/test/java/com/pdg/adventure/view/command/CommandEditorViewRoutingTest.java
@@ -100,7 +100,7 @@ class CommandEditorViewRoutingTest extends BrowserlessTest {
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1"),
                 new RouteParam(RouteIds.COMMAND_ID.getValue(), "go|north|")));
 
-        assertThat(view.getPageTitle()).isEqualTo("Edit Command #go|north|");
+        assertThat(view.getPageTitle()).isEqualTo("Edit Command: go north");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }
@@ -131,7 +131,7 @@ class CommandEditorViewRoutingTest extends BrowserlessTest {
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1"),
                 new RouteParam(RouteIds.COMMAND_ID.getValue(), "jump%7C%7Csea")));
 
-        assertThat(view.getPageTitle()).isEqualTo("Edit Command #jump||sea");
+        assertThat(view.getPageTitle()).isEqualTo("Edit Command: jump sea");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }
@@ -162,7 +162,7 @@ class CommandEditorViewRoutingTest extends BrowserlessTest {
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1"),
                 new RouteParam(RouteIds.COMMAND_ID.getValue(), "jump|100%|sea")));
 
-        assertThat(view.getPageTitle()).isEqualTo("Edit Command #jump|100%|sea");
+        assertThat(view.getPageTitle()).isEqualTo("Edit Command: jump 100% sea");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }
@@ -193,7 +193,7 @@ class CommandEditorViewRoutingTest extends BrowserlessTest {
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1"),
                 new RouteParam(RouteIds.COMMAND_ID.getValue(), "a+b||sea")));
 
-        assertThat(view.getPageTitle()).isEqualTo("Edit Command #a+b||sea");
+        assertThat(view.getPageTitle()).isEqualTo("Edit Command: a+b sea");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }

--- a/src/test/java/com/pdg/adventure/view/command/CommandsMenuViewRoutingTest.java
+++ b/src/test/java/com/pdg/adventure/view/command/CommandsMenuViewRoutingTest.java
@@ -88,6 +88,7 @@ class CommandsMenuViewRoutingTest extends BrowserlessTest {
     void beforeEnter_locationScoped_validIds_populatesGridFromLocationCommands() {
         LocationData location = new LocationData();
         location.setId("loc-1");
+        location.getDescriptionData().setShortDescription("the dunes");
         location.setCommandProviderData(providerWithOneCommand());
         AdventureData adventure = new AdventureData();
         adventure.setId("adv-1");
@@ -99,7 +100,7 @@ class CommandsMenuViewRoutingTest extends BrowserlessTest {
                 new RouteParam(RouteIds.ADVENTURE_ID.getValue(), "adv-1"),
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1")));
 
-        assertThat(view.getPageTitle()).isEqualTo("Commands for location #loc-1");
+        assertThat(view.getPageTitle()).isEqualTo("Commands for the dunes");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }
@@ -108,6 +109,7 @@ class CommandsMenuViewRoutingTest extends BrowserlessTest {
     void beforeEnter_itemScoped_validIds_populatesGridFromItemCommands() {
         ItemData item = new ItemData();
         item.setId("item-1");
+        item.getDescriptionData().setShortDescription("a rusty key");
         item.setCommandProviderData(providerWithOneCommand());
         ItemContainerData container = new ItemContainerData("loc-1");
         container.setItems(List.of(item));
@@ -125,7 +127,7 @@ class CommandsMenuViewRoutingTest extends BrowserlessTest {
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1"),
                 new RouteParam(RouteIds.ITEM_ID.getValue(), "item-1")));
 
-        assertThat(view.getPageTitle()).isEqualTo("Commands for item #item-1");
+        assertThat(view.getPageTitle()).isEqualTo("Commands for a rusty key");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }

--- a/src/test/java/com/pdg/adventure/view/direction/DirectionEditorViewEdgeCasesTest.java
+++ b/src/test/java/com/pdg/adventure/view/direction/DirectionEditorViewEdgeCasesTest.java
@@ -182,9 +182,11 @@ class DirectionEditorViewEdgeCasesTest {
         // when
         view.beforeEnter(beforeEnterEvent);
 
-        // then
+        // then — title is built from the resolved direction's short description, not the
+        // raw (possibly huge) route parameter, so it must not echo longId back verbatim.
         String title = view.getPageTitle();
-        assertThat(title).contains(longId);
+        assertThat(title).startsWith("Edit Direction");
+        assertThat(title).doesNotContain(longId);
     }
 
     @Test
@@ -202,7 +204,7 @@ class DirectionEditorViewEdgeCasesTest {
 
         // then
         String title = view.getPageTitle();
-        assertThat(title).contains("Edit Direction #");
+        assertThat(title).startsWith("Edit Direction");
     }
 
     @Test
@@ -219,7 +221,7 @@ class DirectionEditorViewEdgeCasesTest {
         view.beforeEnter(beforeEnterEvent);
 
         // when/then
-        assertThat(view.getPageTitle()).isEqualTo("Edit Direction #nonexistent-id");
+        assertThat(view.getPageTitle()).startsWith("Edit Direction");
     }
 
     @Test

--- a/src/test/java/com/pdg/adventure/view/direction/DirectionEditorViewNavigationTest.java
+++ b/src/test/java/com/pdg/adventure/view/direction/DirectionEditorViewNavigationTest.java
@@ -125,7 +125,7 @@ class DirectionEditorViewNavigationTest {
         view.beforeEnter(beforeEnterEvent);
 
         // then
-        assertThat(view.getPageTitle()).isEqualTo("Edit Direction #direction-123");
+        assertThat(view.getPageTitle()).isEqualTo("Edit Direction: Go north");
     }
 
     @Test
@@ -173,21 +173,21 @@ class DirectionEditorViewNavigationTest {
     }
 
     @Test
-    void getPageTitle_afterEditNavigation_shouldContainDirectionId() {
+    void getPageTitle_afterEditNavigation_shouldContainDirectionShortDescription() {
         // given
         when(beforeEnterEvent.getRouteParameters()).thenReturn(routeParameters);
         when(routeParameters.get(RouteIds.ADVENTURE_ID.getValue())).thenReturn(Optional.of("adventure-1"));
         when(routeParameters.get(RouteIds.LOCATION_ID.getValue())).thenReturn(Optional.of("location-1"));
         when(accessService.findAdventureById(eq("adventure-1"), any(UserData.class)))
                 .thenReturn(Optional.of(adventureData));
-        when(routeParameters.get("directionId")).thenReturn(Optional.of("abc-123"));
+        when(routeParameters.get("directionId")).thenReturn(Optional.of("direction-123"));
 
         // when
         view.beforeEnter(beforeEnterEvent);
         String title = view.getPageTitle();
 
         // then
-        assertThat(title).contains("abc-123");
+        assertThat(title).contains("Go north");
         assertThat(title).startsWith("Edit Direction");
     }
 

--- a/src/test/java/com/pdg/adventure/view/direction/DirectionsMenuViewTest.java
+++ b/src/test/java/com/pdg/adventure/view/direction/DirectionsMenuViewTest.java
@@ -70,6 +70,7 @@ class DirectionsMenuViewTest extends BrowserlessTest {
         direction.setId("dir-1");
         LocationData location = new LocationData();
         location.setId("loc-1");
+        location.getDescriptionData().setShortDescription("the old jetty");
         location.setDirectionsData(Set.of(direction));
         AdventureData adventure = new AdventureData();
         adventure.setId("adv-1");
@@ -81,6 +82,7 @@ class DirectionsMenuViewTest extends BrowserlessTest {
                 new RouteParam(RouteIds.ADVENTURE_ID.getValue(), "adv-1"),
                 new RouteParam(RouteIds.LOCATION_ID.getValue(), "loc-1")));
 
+        assertThat(view.getPageTitle()).isEqualTo("Exits for the old jetty");
         Grid<?> grid = find(Grid.class, view).single();
         assertThat(test(grid).size()).isEqualTo(1);
     }

--- a/src/test/java/com/pdg/adventure/view/item/ItemEditorViewRoutingTest.java
+++ b/src/test/java/com/pdg/adventure/view/item/ItemEditorViewRoutingTest.java
@@ -73,6 +73,7 @@ class ItemEditorViewRoutingTest extends BrowserlessTest {
     void beforeEnter_validIds_populatesFormFromResolvedItem() {
         ItemData item = new ItemData();
         item.setId("item-1");
+        item.getDescriptionData().setShortDescription("a rusty key");
         ItemContainerData container = new ItemContainerData("loc-1");
         container.setItems(List.of(item));
         LocationData location = new LocationData();
@@ -92,6 +93,7 @@ class ItemEditorViewRoutingTest extends BrowserlessTest {
         assertThat(find(TextField.class, view).withValue("item-1").exists()).isTrue();
         assertThat(find(TextField.class, view).withValue("loc-1").exists()).isTrue();
         assertThat(find(TextField.class, view).withValue("adv-1").exists()).isTrue();
+        assertThat(view.getPageTitle()).isEqualTo("Edit Item: a rusty key");
     }
 
     @Test

--- a/src/test/java/com/pdg/adventure/view/location/LocationEditorViewRoutingTest.java
+++ b/src/test/java/com/pdg/adventure/view/location/LocationEditorViewRoutingTest.java
@@ -66,6 +66,7 @@ class LocationEditorViewRoutingTest extends BrowserlessTest {
     void beforeEnter_validIds_populatesFormFromResolvedData() {
         LocationData location = new LocationData();
         location.setId("loc-1");
+        location.getDescriptionData().setShortDescription("the old jetty");
         AdventureData adventure = new AdventureData();
         adventure.setId("adv-1");
         adventure.setLocationData(Map.of("loc-1", location));
@@ -78,6 +79,7 @@ class LocationEditorViewRoutingTest extends BrowserlessTest {
 
         assertThat(find(TextField.class, view).withValue("loc-1").exists()).isTrue();
         assertThat(find(TextField.class, view).withValue("adv-1").exists()).isTrue();
+        assertThat(view.getPageTitle()).isEqualTo("Edit Location: the old jetty");
     }
 
     @Test


### PR DESCRIPTION
Replace technical IDs with user-friendly titles/descriptions in page titles across editor and menu views (Adventure, Location, Direction, Item, Command, Message). Add corresponding routing tests to verify title generation from resolved data.