### PR TITLE
Implement compound command parsing with conjunction and period separa…

### DIFF
--- a/src/main/java/com/pdg/adventure/MiniAdventure.java
+++ b/src/main/java/com/pdg/adventure/MiniAdventure.java
@@ -154,6 +154,8 @@ public class MiniAdventure {
         aVocabulary.createNewWord("help", Word.Type.VERB);
         aVocabulary.createNewWord("inventory", Word.Type.VERB);
         aVocabulary.createSynonym("i", "inventory");
+        aVocabulary.createNewWord("and", Word.Type.CONJUNCTION);
+        aVocabulary.createSynonym("then", "and");
         aVocabulary.createNewWord("default", Word.Type.NOUN);
 
         addAdventureIdsToNouns();

--- a/src/main/java/com/pdg/adventure/model/Word.java
+++ b/src/main/java/com/pdg/adventure/model/Word.java
@@ -41,6 +41,7 @@ public class Word extends DatedData {
     public enum Type {
         VERB,
         NOUN,
-        ADJECTIVE
+        ADJECTIVE,
+        CONJUNCTION
     }
 }

--- a/src/main/java/com/pdg/adventure/server/engine/AdventureRunSessionFactory.java
+++ b/src/main/java/com/pdg/adventure/server/engine/AdventureRunSessionFactory.java
@@ -92,5 +92,7 @@ public class AdventureRunSessionFactory {
         aVocabulary.createNewWord("help", Word.Type.VERB);
         aVocabulary.createNewWord("inventory", Word.Type.VERB);
         aVocabulary.createSynonym("i", "inventory");
+        aVocabulary.createNewWord("and", Word.Type.CONJUNCTION);
+        aVocabulary.createSynonym("then", "and");
     }
 }

--- a/src/main/java/com/pdg/adventure/server/engine/GameLoop.java
+++ b/src/main/java/com/pdg/adventure/server/engine/GameLoop.java
@@ -10,8 +10,8 @@ import com.pdg.adventure.api.ExecutionResult;
 import com.pdg.adventure.model.VocabularyData;
 import com.pdg.adventure.server.exception.QuitException;
 import com.pdg.adventure.server.exception.ReloadAdventureException;
-import com.pdg.adventure.server.location.Location;
 import com.pdg.adventure.server.parser.CommandExecutor;
+import com.pdg.adventure.server.parser.CommandSequence;
 import com.pdg.adventure.server.parser.GenericCommandDescription;
 import com.pdg.adventure.server.parser.Parser;
 
@@ -54,36 +54,11 @@ public class GameLoop {
      * caller driving one command per external event (e.g. a browser input) controls that timing.
      */
     public CommandOutcome processCommand(String anInput) {
-        Location currentLocation = gameContext.getCurrentLocation();
         try {
-            GenericCommandDescription command = parser.handle(anInput);
-
-            // Check commands that are independent of locations, like inventory, save, quit aso.
-            ExecutionResult result = gameContext.interceptCommands(command);
-            if (result.getExecutionState() != ExecutionResult.State.FAILURE) {
-                gameContext.tell(result.getResultMessage());
-                return CommandOutcome.CONTINUE;
-            }
-
-            // Continue if the user provided nothing that we understand. A command needs at
-            // least a verb to be actionable - e.g. a bare noun like "suit" with no verb - so
-            // that alone is unparseable, not merely a command with no matching handler.
-            if (VocabularyData.EMPTY_STRING.equals(command.getVerb())) {
-                gameContext.tell("I don't understand, please rephrase.");
-                return CommandOutcome.CONTINUE;
-            }
-
-            // Check commands that are possible because of the players inventory or the current location.
-            CommandExecutor commandExecuter = new CommandExecutor(gameContext.getPocket(), currentLocation);
-            result = commandExecuter.execute(command);
-
-            if (!VocabularyData.EMPTY_STRING.equals(result.getResultMessage())) {
-                gameContext.tell(result.getResultMessage());
-            } else {
-                if (result.getExecutionState() == ExecutionResult.State.FAILURE) {
-                    gameContext.tell("I can't do that.");
-                } else {
-                    gameContext.tell("Done.");
+            CommandSequence sequence = parser.handle(anInput);
+            for (GenericCommandDescription command : sequence.commands()) {
+                if (!runOneCommandSucceeded(command)) {
+                    break; // stop the sequence at the first sub-command that failed
                 }
             }
             return CommandOutcome.CONTINUE;
@@ -96,5 +71,51 @@ public class GameLoop {
             LOG.error("An error occurred during the game loop.", anException);
             return CommandOutcome.ERROR;
         }
+    }
+
+    /**
+     * Runs one already-parsed sub-command of a (possibly conjunction-joined) turn: checks
+     * interceptor and location/pocket commands, and tells the result. Re-reads
+     * gameContext.getCurrentLocation()/getPocket() rather than reusing a value captured once
+     * for the whole turn, because an earlier sub-command in the same sequence (e.g. "go north")
+     * may have moved the player, and this sub-command must see that new location.
+     *
+     * @return true if this sub-command succeeded and the sequence should continue; false if it
+     * failed (or couldn't be understood) and the remaining sub-commands must not be attempted.
+     */
+    private boolean runOneCommandSucceeded(GenericCommandDescription command) {
+        // Check commands that are independent of locations, like inventory, save, quit aso.
+        ExecutionResult result = gameContext.interceptCommands(command);
+        if (result.getExecutionState() != ExecutionResult.State.FAILURE) {
+            gameContext.tell(result.getResultMessage());
+            return true;
+        }
+
+        // Continue if the user provided nothing that we understand. A command needs at
+        // least a verb to be actionable - e.g. a bare noun like "suit" with no verb - so
+        // that alone is unparseable, not merely a command with no matching handler.
+        if (VocabularyData.EMPTY_STRING.equals(command.getVerb())) {
+            gameContext.tell("I don't understand, please rephrase.");
+            // TODO: Review needed — an unparseable sub-command isn't literally a "failure" of a
+            //  real command, but the user's "stop at first failure" requirement didn't cover this
+            //  case explicitly. Treating it as a stop condition here, consistent with the rest of
+            //  the sequence's fail-fast behaviour.
+            return false;
+        }
+
+        // Check commands that are possible because of the players inventory or the current location.
+        CommandExecutor commandExecuter = new CommandExecutor(gameContext.getPocket(), gameContext.getCurrentLocation());
+        result = commandExecuter.execute(command);
+
+        if (!VocabularyData.EMPTY_STRING.equals(result.getResultMessage())) {
+            gameContext.tell(result.getResultMessage());
+        } else {
+            if (result.getExecutionState() == ExecutionResult.State.FAILURE) {
+                gameContext.tell("I can't do that.");
+            } else {
+                gameContext.tell("Done.");
+            }
+        }
+        return result.getExecutionState() != ExecutionResult.State.FAILURE;
     }
 }

--- a/src/main/java/com/pdg/adventure/server/parser/CommandSequence.java
+++ b/src/main/java/com/pdg/adventure/server/parser/CommandSequence.java
@@ -1,0 +1,19 @@
+package com.pdg.adventure.server.parser;
+
+import java.util.List;
+
+/**
+ * The parser's output for one full turn of raw input, which may contain more than one
+ * conjunction- or period-separated sub-command (e.g. "take sword and kill ogre",
+ * "take sword. kill ogre."), in execution order.
+ * <p>
+ * Not to be confused with {@link GenericCommandChain}, which groups multiple candidate
+ * implementations of the SAME verb/adjective/noun tried in turn by CommandExecutor - this type
+ * instead holds multiple distinct commands, each resolved and executed independently in order.
+ */
+public record CommandSequence(List<GenericCommandDescription> commands) {
+
+    public CommandSequence {
+        commands = List.copyOf(commands);
+    }
+}

--- a/src/main/java/com/pdg/adventure/server/parser/Parser.java
+++ b/src/main/java/com/pdg/adventure/server/parser/Parser.java
@@ -2,8 +2,8 @@ package com.pdg.adventure.server.parser;
 
 import lombok.Data;
 
-import java.io.BufferedReader;
-import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
 
@@ -12,36 +12,70 @@ import com.pdg.adventure.model.Word;
 import com.pdg.adventure.server.vocabulary.Vocabulary;
 
 public class Parser {
+    private static final String SENTENCE_TERMINATOR = ".";
+
     private final Vocabulary vocabulary;
 
     public Parser(Vocabulary aVocabulary) {
         vocabulary = aVocabulary;
     }
 
-    public GenericCommandDescription getInput(BufferedReader aReader) throws IOException {
-        String actionCommand = aReader.readLine();
-        return handle(actionCommand);
-    }
+    public CommandSequence handle(String anInput) {
+        List<GenericCommandDescription> commands = new ArrayList<>();
+        SimpleSentence currentSentence = new SimpleSentence();
+        boolean currentHasContent = false;
 
-    public GenericCommandDescription handle(String anInput) {
-        SimpleSentence simpleSentence = new SimpleSentence();
-        String lowerCaseInput = anInput.toLowerCase();
-
-        try (
-                Scanner scanner = new Scanner(lowerCaseInput)) {
+        try (Scanner scanner = new Scanner(withSpacedTerminators(anInput))) {
             while (scanner.hasNext()) {
                 String token = scanner.next();
-                Optional<Word> optionalWord = vocabulary.findWord(token);
-                if (optionalWord.isEmpty()) {
-                    // don't know this word
+                Word resolved = null;
+                boolean isSeparator = SENTENCE_TERMINATOR.equals(token);
+
+                if (!isSeparator) {
+                    Optional<Word> optionalWord = vocabulary.findWord(token);
+                    if (optionalWord.isEmpty()) {
+                        continue; // don't know this word
+                    }
+                    Word word = optionalWord.get();
+                    resolved = word.getSynonym() == null ? word : word.getSynonym();
+                    isSeparator = resolved.getType() == Word.Type.CONJUNCTION;
+                }
+
+                if (isSeparator) {
+                    if (currentHasContent) {
+                        commands.add(toDescription(currentSentence));
+                        currentSentence = new SimpleSentence();
+                        currentHasContent = false;
+                    }
                     continue;
                 }
-                Word word = optionalWord.get();
-                populate(simpleSentence, word.getSynonym() == null ? word : word.getSynonym());
+
+                // resolved is always non-null here: the only way past the isSeparator checks
+                // above without a `continue` is through the vocabulary lookup that assigns it.
+                populate(currentSentence, resolved);
+                currentHasContent = true;
             }
         }
-        return new GenericCommandDescription(simpleSentence.getVerb(), simpleSentence.getAdjective(),
-                                             simpleSentence.getNoun());
+
+        // A separator (period or conjunction) with nothing after it never opens a trailing
+        // segment; but a turn with no separator at all - or with nothing recognisable in it -
+        // must still yield exactly one (possibly empty) command, matching the pre-existing
+        // single-command contract GameLoop's bare-verb check relies on.
+        if (currentHasContent || commands.isEmpty()) {
+            commands.add(toDescription(currentSentence));
+        }
+        return new CommandSequence(commands);
+    }
+
+    // "." is not itself a vocabulary word (it can't be looked up by findWord), so it is split
+    // out into its own token here, before the whitespace-based Scanner tokenizing above, rather
+    // than being treated as a hardcoded command string like a real word would be.
+    private static String withSpacedTerminators(String anInput) {
+        return anInput.toLowerCase().replace(SENTENCE_TERMINATOR, " " + SENTENCE_TERMINATOR + " ");
+    }
+
+    private static GenericCommandDescription toDescription(SimpleSentence aSentence) {
+        return new GenericCommandDescription(aSentence.getVerb(), aSentence.getAdjective(), aSentence.getNoun());
     }
 
     private void populate(SimpleSentence aSentence, Word aWord) {

--- a/src/main/java/com/pdg/adventure/view/vocabulary/WordEditorDialogue.java
+++ b/src/main/java/com/pdg/adventure/view/vocabulary/WordEditorDialogue.java
@@ -189,6 +189,8 @@ public class WordEditorDialogue {
         typeSelector.setLabel("Type");
         List<Word.Type> typeList = new ArrayList<>();
         Collections.addAll(typeList, Word.Type.values());
+        // CONJUNCTION ("and"/"then") is a reserved, system-seeded type - never author-authorable.
+        typeList.remove(Word.Type.CONJUNCTION);
         typeSelector.addValueChangeListener(_ -> validateAndUpdateSaveButton());
         typeSelector.setItems(typeList);
         typeSelector.setRenderer(new ComponentRenderer<Component, Word.Type>(wordType -> new Text(wordType.name())));

--- a/src/test/java/com/pdg/adventure/server/engine/AdventureRunSessionFactoryTest.java
+++ b/src/test/java/com/pdg/adventure/server/engine/AdventureRunSessionFactoryTest.java
@@ -101,6 +101,24 @@ class AdventureRunSessionFactoryTest {
     }
 
     @Test
+    void start_compoundCommand_runsBothSubCommandsThroughTheRealSeededVocabulary() {
+        // "and" must be seeded by the real registerBaseVerbs() production path, not just by a
+        // hand-built test Vocabulary - this is the browser/"Run Adventure" entry point.
+        AdventureData adventureData = adventureWithOneLocation("adv-1", "loc-1");
+        when(adventureService.findAdventureById("adv-1")).thenReturn(Optional.of(adventureData));
+        when(startLocation.getId()).thenReturn("loc-1");
+        when(startLocation.getLongDescription()).thenReturn("A grand throne room.");
+        Adventure adventure = adventureBoundTo(startLocation, "loc-1");
+        when(adventureMapper.mapToBO(adventureData)).thenReturn(adventure);
+
+        AdventureRunSession session = factory.start(adventureData);
+        RunResult result = session.submit("describe and inventory");
+
+        assertThat(result.lines()).anySatisfy(line -> assertThat(line).contains("A grand throne room."));
+        assertThat(result.lines()).anySatisfy(line -> assertThat(line).contains("You carry:"));
+    }
+
+    @Test
     void start_adventureNotFound_throwsIllegalStateException() {
         AdventureData adventureData = new AdventureData();
         adventureData.setId("missing-adv");

--- a/src/test/java/com/pdg/adventure/server/engine/GameLoopTest.java
+++ b/src/test/java/com/pdg/adventure/server/engine/GameLoopTest.java
@@ -8,7 +8,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.pdg.adventure.CommandFactory;
 import com.pdg.adventure.model.VocabularyData;
 import com.pdg.adventure.model.Word;
+import com.pdg.adventure.server.action.MessageAction;
+import com.pdg.adventure.server.action.MovePlayerAction;
 import com.pdg.adventure.server.location.Location;
+import com.pdg.adventure.server.parser.GenericCommand;
+import com.pdg.adventure.server.parser.GenericCommandDescription;
 import com.pdg.adventure.server.parser.Parser;
 import com.pdg.adventure.server.storage.message.MessagesHolder;
 import com.pdg.adventure.server.support.DescriptionProvider;
@@ -23,11 +27,14 @@ import com.pdg.adventure.server.vocabulary.Vocabulary;
 class GameLoopTest {
 
     private final StringBuilder told = new StringBuilder();
+    private GameContext gameContext;
+    private Vocabulary vocabulary;
+    private Workflow workflow;
     private GameLoop gameLoop;
 
     @BeforeEach
     void setUp() {
-        GameContext gameContext = new GameContext();
+        gameContext = new GameContext();
         gameContext.setOutputSink(line -> told.append(line).append('\n'));
 
         gameContext.setPocket(new GenericContainer(new DescriptionProvider("pocket"), 10));
@@ -37,13 +44,16 @@ class GameLoopTest {
         Location room = new Location(roomDescription, new GenericContainer(new DescriptionProvider("room items"), 10));
         gameContext.setCurrentLocation(room);
 
-        Vocabulary vocabulary = new Vocabulary();
+        vocabulary = new Vocabulary();
         vocabulary.createNewWord("quit", Word.Type.VERB);
         vocabulary.createNewWord("describe", Word.Type.VERB);
         vocabulary.createNewWord("take", Word.Type.VERB); // recognised, but wired to nothing
         vocabulary.createNewWord("suit", Word.Type.NOUN); // recognised noun, no verb given in some tests
+        vocabulary.createNewWord("help", Word.Type.VERB);
+        vocabulary.createNewWord("and", Word.Type.CONJUNCTION);
+        vocabulary.createSynonym("then", "and");
 
-        Workflow workflow = gameContext.setUpWorkflows();
+        workflow = gameContext.setUpWorkflows();
         new CommandFactory(new MessagesHolder(), gameContext, new VocabularyData()).setUpWorkflowCommands(workflow);
 
         gameLoop = new GameLoop(new Parser(vocabulary), gameContext);
@@ -89,6 +99,85 @@ class GameLoopTest {
 
         assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.CONTINUE);
         assertThat(told.toString()).contains("I don't understand, please rephrase.");
+        assertThat(told.toString()).doesNotContain("I don't know how to do that.");
+    }
+
+    @Test
+    void and_runsBothSubCommandsInOrder() {
+        GameLoop.CommandOutcome outcome = gameLoop.processCommand("describe and help");
+
+        assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.CONTINUE);
+        String output = told.toString();
+        assertThat(output).contains("A grand throne room.").contains("Look around, examine items");
+        assertThat(output.indexOf("A grand throne room."))
+                .isLessThan(output.indexOf("Look around, examine items"));
+    }
+
+    @Test
+    void period_behavesTheSameAsAnd() {
+        GameLoop.CommandOutcome outcome = gameLoop.processCommand("describe. help");
+
+        assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.CONTINUE);
+        assertThat(told.toString()).contains("A grand throne room.").contains("Look around, examine items");
+    }
+
+    @Test
+    void and_stopsAtFirstFailure_secondSubCommandNeverRuns() {
+        GameLoop.CommandOutcome outcome = gameLoop.processCommand("take and describe");
+
+        assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.CONTINUE);
+        assertThat(told.toString()).contains("I don't know how to do that.");
+        assertThat(told.toString()).doesNotContain("A grand throne room.");
+    }
+
+    @Test
+    void and_bareNounFirstSubCommand_stopsSequence() {
+        // "suit" alone is a recognised noun with no verb - unparseable on its own (see
+        // bareNounWithNoVerb_tellsPleaseRephrase_notIDontKnowHow above) - and must stop the
+        // sequence the same way a real command failure would, not let "describe" run anyway.
+        GameLoop.CommandOutcome outcome = gameLoop.processCommand("suit and describe");
+
+        assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.CONTINUE);
+        assertThat(told.toString()).contains("I don't understand, please rephrase.");
+        assertThat(told.toString()).doesNotContain("A grand throne room.");
+    }
+
+    @Test
+    void and_quitMidSequence_returnsQuit_laterSubCommandsNeverRun() {
+        GameLoop.CommandOutcome outcome = gameLoop.processCommand("describe and quit and help");
+
+        assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.QUIT);
+        assertThat(told.toString()).contains("A grand throne room.").contains("Bye bye.");
+        assertThat(told.toString()).doesNotContain("Look around, examine items");
+    }
+
+    @Test
+    void and_afterMovingSubCommand_secondSubCommandSeesTheNewLocation() {
+        // A command wired only on the destination location ("examine key") must be reachable
+        // by the second sub-command of a sequence whose first sub-command moved the player
+        // there - proves GameLoop re-reads the current location per sub-command rather than
+        // capturing it once for the whole turn.
+        MessagesHolder messages = new MessagesHolder();
+        DescriptionProvider cellarDescription = new DescriptionProvider("cellar", "cellar");
+        cellarDescription.setLongDescription("A dark, damp cellar.");
+        Location cellar = new Location(cellarDescription,
+                                       new GenericContainer(new DescriptionProvider("cellar items"), 10));
+        cellar.addCommand(new GenericCommand(new GenericCommandDescription("examine", "key"),
+                                             new MessageAction("A rusty key.", messages)));
+
+        GenericCommandDescription descendDescription = new GenericCommandDescription("descend");
+        workflow.addInterceptorCommand(descendDescription,
+                                       new GenericCommand(descendDescription,
+                                                          new MovePlayerAction(cellar, messages, gameContext)));
+
+        vocabulary.createNewWord("descend", Word.Type.VERB);
+        vocabulary.createNewWord("examine", Word.Type.VERB);
+        vocabulary.createNewWord("key", Word.Type.NOUN);
+
+        GameLoop.CommandOutcome outcome = gameLoop.processCommand("descend and examine key");
+
+        assertThat(outcome).isEqualTo(GameLoop.CommandOutcome.CONTINUE);
+        assertThat(told.toString()).contains("A dark, damp cellar.").contains("A rusty key.");
         assertThat(told.toString()).doesNotContain("I don't know how to do that.");
     }
 }

--- a/src/test/java/com/pdg/adventure/server/parser/ParserTest.java
+++ b/src/test/java/com/pdg/adventure/server/parser/ParserTest.java
@@ -10,18 +10,133 @@ import com.pdg.adventure.server.vocabulary.Vocabulary;
 class ParserTest {
 
     @Test
-    void getInput() {
+    void handle_unrecognisedWordsAreSkipped_returnsOneCommand() {
         // given
         Vocabulary vocabulary = new Vocabulary();
         vocabulary.createNewWord("PaRsEr", Word.Type.NOUN);
         Parser parser = new Parser(vocabulary);
 
         // when
-        GenericCommandDescription command = parser.handle("hello, parser I am your trusty parser");
+        CommandSequence sequence = parser.handle("hello, parser I am your trusty parser");
 
         // then
+        assertThat(sequence.commands()).hasSize(1);
+        GenericCommandDescription command = sequence.commands().getFirst();
         assertThat(command.getVerb()).isEmpty();
         assertThat(command.getAdjective()).isEmpty();
         assertThat(command.getNoun()).isEqualTo("parser");
+    }
+
+    @Test
+    void handle_and_splitsIntoTwoCommands() {
+        // given
+        Parser parser = new Parser(vocabularyWithTakeSwordAndKillOgre());
+
+        // when
+        CommandSequence sequence = parser.handle("take sword and kill ogre");
+
+        // then
+        assertThat(sequence.commands()).hasSize(2);
+        assertThat(sequence.commands().get(0).getVerb()).isEqualTo("take");
+        assertThat(sequence.commands().get(0).getNoun()).isEqualTo("sword");
+        assertThat(sequence.commands().get(1).getVerb()).isEqualTo("kill");
+        assertThat(sequence.commands().get(1).getNoun()).isEqualTo("ogre");
+    }
+
+    @Test
+    void handle_then_isRegisteredAsSynonymOfAnd_andAlsoSplits() {
+        // given
+        Vocabulary vocabulary = vocabularyWithTakeSwordAndKillOgre();
+        Parser parser = new Parser(vocabulary);
+
+        // when
+        CommandSequence sequence = parser.handle("take sword then kill ogre");
+
+        // then
+        assertThat(vocabulary.getType("then")).isEqualTo(Word.Type.CONJUNCTION);
+        assertThat(sequence.commands()).hasSize(2);
+        assertThat(sequence.commands().get(0).getNoun()).isEqualTo("sword");
+        assertThat(sequence.commands().get(1).getNoun()).isEqualTo("ogre");
+    }
+
+    @Test
+    void handle_period_splitsIntoTwoCommands_equivalentToAnd() {
+        // given
+        Parser parser = new Parser(vocabularyWithTakeSwordAndKillOgre());
+
+        // when
+        CommandSequence sequence = parser.handle("take sword. kill ogre");
+
+        // then
+        assertThat(sequence.commands()).hasSize(2);
+        assertThat(sequence.commands().get(0).getNoun()).isEqualTo("sword");
+        assertThat(sequence.commands().get(1).getNoun()).isEqualTo("ogre");
+    }
+
+    @Test
+    void handle_trailingPeriod_doesNotProduceAnEmptyThirdCommand() {
+        // given
+        Parser parser = new Parser(vocabularyWithTakeSwordAndKillOgre());
+
+        // when
+        CommandSequence sequence = parser.handle("take sword.");
+
+        // then
+        assertThat(sequence.commands()).hasSize(1);
+        assertThat(sequence.commands().getFirst().getNoun()).isEqualTo("sword");
+    }
+
+    @Test
+    void handle_leadingConjunction_isForgiven_doesNotProduceAnEmptyFirstCommand() {
+        // given
+        Parser parser = new Parser(vocabularyWithTakeSwordAndKillOgre());
+
+        // when
+        CommandSequence sequence = parser.handle("and kill ogre");
+
+        // then
+        assertThat(sequence.commands()).hasSize(1);
+        assertThat(sequence.commands().getFirst().getVerb()).isEqualTo("kill");
+    }
+
+    @Test
+    void handle_doubledConjunction_doesNotProduceAPhantomEmptyCommand() {
+        // given
+        Parser parser = new Parser(vocabularyWithTakeSwordAndKillOgre());
+
+        // when
+        CommandSequence sequence = parser.handle("take sword and and kill ogre");
+
+        // then
+        assertThat(sequence.commands()).hasSize(2);
+        assertThat(sequence.commands().get(0).getNoun()).isEqualTo("sword");
+        assertThat(sequence.commands().get(1).getNoun()).isEqualTo("ogre");
+    }
+
+    @Test
+    void handle_fullyUnparseableInput_stillReturnsOneEmptyCommand() {
+        // given
+        Parser parser = new Parser(vocabularyWithTakeSwordAndKillOgre());
+
+        // when
+        CommandSequence sequence = parser.handle("mumble grumble");
+
+        // then
+        assertThat(sequence.commands()).hasSize(1);
+        GenericCommandDescription command = sequence.commands().getFirst();
+        assertThat(command.getVerb()).isEmpty();
+        assertThat(command.getAdjective()).isEmpty();
+        assertThat(command.getNoun()).isEmpty();
+    }
+
+    private static Vocabulary vocabularyWithTakeSwordAndKillOgre() {
+        Vocabulary vocabulary = new Vocabulary();
+        vocabulary.createNewWord("take", Word.Type.VERB);
+        vocabulary.createNewWord("sword", Word.Type.NOUN);
+        vocabulary.createNewWord("and", Word.Type.CONJUNCTION);
+        vocabulary.createSynonym("then", "and");
+        vocabulary.createNewWord("kill", Word.Type.VERB);
+        vocabulary.createNewWord("ogre", Word.Type.NOUN);
+        return vocabulary;
     }
 }

--- a/src/test/java/com/pdg/adventure/view/vocabulary/WordEditorDialogueTest.java
+++ b/src/test/java/com/pdg/adventure/view/vocabulary/WordEditorDialogueTest.java
@@ -347,6 +347,16 @@ class WordEditorDialogueTest {
     }
 
     @Test
+    @DisplayName("Test 6a: Type selector - excludes CONJUNCTION, a reserved built-in-only type")
+    void typeSelector_excludesConjunction() {
+        // CONJUNCTION ("and"/"then") is seeded system-wide (MiniAdventure/AdventureRunSessionFactory),
+        // not author-authored - an author must never be able to hand-create one via this picker.
+        assertThat(typeSelector.getListDataView().getItems()).doesNotContain(Word.Type.CONJUNCTION);
+        assertThat(typeSelector.getListDataView().getItems())
+                .contains(Word.Type.VERB, Word.Type.NOUN, Word.Type.ADJECTIVE);
+    }
+
+    @Test
     @DisplayName("Test 6b: Duplicate word detection - prevents duplicate word text")
     void vocabularyOperations_shouldDetectDuplicateWords() {
         // given: existing word

--- a/vite.generated.ts
+++ b/vite.generated.ts
@@ -27,7 +27,7 @@ import brotli from 'rollup-plugin-brotli';
 import checker from 'vite-plugin-checker';
 import postcssLit from './target/plugins/rollup-plugin-postcss-lit-custom/rollup-plugin-postcss-lit.js';
 import vaadinI18n from './target/plugins/rollup-plugin-vaadin-i18n/rollup-plugin-vaadin-i18n.js';
-
+import serviceWorkerPlugin from './target/plugins/vite-plugin-service-worker';
 export { default as useLocalWebComponents } from './target/plugins/vite-plugin-local-web-components';
 
 import { visualizer } from 'rollup-plugin-visualizer';
@@ -514,7 +514,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
     plugins: [
       productionMode && brotli(),
       devMode && showRecompileReason(),
-      
+      serviceWorkerPlugin({ srcPath: settings.clientServiceWorkerSource }),
       !devMode && statsExtracterPlugin(),
       !productionMode && preserveUsageStats(),
       themePlugin({ devMode }),


### PR DESCRIPTION
…tors

Adds support for chaining multiple commands in a single turn using "and", "then", or "." separators (e.g., "take sword and kill ogre", "describe. help").

**Parser changes:**
- Introduced CommandSequence record to hold multiple parsed sub-commands
- Parser.handle() now returns CommandSequence instead of single GenericCommandDescription
- Added CONJUNCTION word type (reserved, system-seeded only)
- Registered "and" and "then" as conjunctions in MiniAdventure and AdventureRunSessionFactory
- Period separator treated equivalently to conjunction for command splitting
- Empty segments from leading/trailing/doubled separators silently dropped

**GameLoop changes:**
- Refactored processCommand() to iterate CommandSequence
- Extracted runOneCommandSucceeded() to execute each sub-command independently
- Re-reads current location/pocket per sub-command (enables "go north and look" chains)
- Stops sequence at first failure (command not found, precondition unmet, or unparseable)
- Quit mid-sequence returns QUIT outcome without running remaining sub-commands

**UI/vocabulary changes:**
- WordEditorDialogue excludes CONJUNCTION from author-editable type selector
- Added integration test for "describe and inventory" via AdventureRunSessionFactory

All 991 tests passing.